### PR TITLE
Restyle inline code blocks

### DIFF
--- a/components/layout/main-content/article-container/ArticleBody.js
+++ b/components/layout/main-content/article-container/ArticleBody.js
@@ -2,7 +2,7 @@ const ArticleBody = props => {
   return (
     <div className='flex justify-center max-w-7xl mx-auto py-4 px-4 lg:py-8 sm:px-6 lg:px-8'>
       <div
-        className='prose 2xl:max-w-[900px] prose-img:rounded-md prose-img:shadow-lg'
+        className='prose 2xl:max-w-[900px] prose-img:rounded-md prose-img:shadow-lg prose-code:before:content-none prose-code:after:content-none prose-code:text-[#e5e7eb] prose-code:bg-[#1f2937] prose-code:py-1 prose-code:rounded-md prose-code:font-normal'
         dangerouslySetInnerHTML={{ __html: props.content }}
       />
     </div>


### PR DESCRIPTION
Remove the back-ticks and have the background/text color match other code blocks.

Slightly hacky, but it works.