### PR TITLE
Check for 'published' in API field arguments, and add it if not included

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -59,9 +59,15 @@ const articlesByFolder = (fields = [], folder) =>
   getArticleSlugs(folder).map(slug => getArticleBySlug(slug, fields, folder));
 
 export const getArticles = (fields = [], containingFolder = '') => {
-  let articles = containingFolder
-    ? articlesByFolder(fields, containingFolder)
-    : allArticles(fields);
+  let fieldsToFetch = fields.includes('published') ? fields : [...fields, 'published'];
 
-  return articles.sort((article1, article2) => (article1.published > article2.published ? -1 : 1));
+  let articles = containingFolder
+    ? articlesByFolder(fieldsToFetch, containingFolder)
+    : allArticles(fieldsToFetch);
+
+  articles.sort((article1, article2) => (article1.published > article2.published ? -1 : 1));
+
+  return fields.includes('published')
+    ? articles
+    : articles.map(({ published, ...article }) => article);
 };


### PR DESCRIPTION
In order to 'sort' the articles, a 'published' field needs to be included in the articles.

So if 'published' is not included in the 'fields' argument, we add it before fetching the articles, sort the articles, then remove 'published' before returning them.